### PR TITLE
Missing vuex in npm install?

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supports:
 2. In module environments, e.g CommonJS:
 
   ``` bash
-  npm install vue firebase vuexfire --save
+  npm install vue vuex firebase vuexfire --save
   ```
 
   ``` js


### PR DESCRIPTION
Shouldn't `vuex`be included in the `npm install` ?