### PR TITLE
Use Vue.set to set nested values in walkSet

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "opinionated"
   ],
   "peerDependencies": {
-    "firebase": ">= 4.0.0"
+    "firebase": ">= 4.0.0",
+    "vue": "*"
   },
   "author": {
     "name": "Eduardo San Martin Morote",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import Vue from 'vue'
+
 export function createSnapshot (doc) {
   // defaults everything to false, so no need to set
   return Object.defineProperty(doc.data(), 'id', {
@@ -65,5 +67,5 @@ export function walkSet (obj, path, value) {
   // global isFinite is different from Number.isFinite
   // it converts values to numbers
   if (isFinite(key)) target.splice(key, 1, value)
-  else target[key] = value
+  else Vue.set(target, key, value)
 }


### PR DESCRIPTION
Currently the state bound by the following code does not trigger view update.

```js
const store = new Vuex.Store({
  state: {
    todos: {
      foo: null,
    },
  },
  actions: {
    setTodosRef: firebaseAction(({ bindFirebaseRef }, { ref }) => {
      bindFirebaseRef('todos.foo', ref);
    }),
  },
});
```

This is due to [Vue's Reactivity Rules](https://vuex.vuejs.org/guide/mutations.html#mutations-follow-vue-s-reactivity-rules). So we should use [Vue.set](https://vuejs.org/v2/api/#Vue-set) to bind values internally.